### PR TITLE
Allow a query call w/o a query parameter

### DIFF
--- a/parse.php
+++ b/parse.php
@@ -248,9 +248,6 @@ class parseRestClient{
 		if(isset($args['query'])){
 			$params['query'] = $args['query'];
 		}
-		else{
-			die('you should use the get method if you are not inluding a query');
-		}
 		if(isset($args['order'])){
 			$params['order'] = $args['order'];
 		}


### PR DESCRIPTION
This is the only way to get all of an object. Order, limit, and skip all still apple in this situation.
