### PR TITLE
added JSON_NUMERIC_CHECK to properly handle numbers encoded as strings

### DIFF
--- a/parse.php
+++ b/parse.php
@@ -131,7 +131,7 @@ class parseRestClient{
 		curl_setopt($c, CURLOPT_URL, $this->parseUrl . $args['url']);
 		
 		if($args['method'] == 'PUT' || $args['method'] == "POST"){
-			$postData = json_encode($args['payload']);
+			$postData = json_encode($args['payload'], JSON_NUMERIC_CHECK);
 			curl_setopt($c, CURLOPT_POSTFIELDS, $postData );
 		}
 		else{


### PR DESCRIPTION
Had a problem with this in my scripts. Was getting a Parse error in my GeoPoints. Adding JSON_NUMERIC_CHECK fixed the error.
