### PR TITLE
Update parseQuery.php

### DIFF
--- a/parseQuery.php
+++ b/parseQuery.php
@@ -44,7 +44,7 @@ class parseQuery extends parseRestClient{
 				$urlParams['skip'] = $this->_skip;
 			}
 			if($this->_count == 1){
-				$urlParams['count'] == '1';
+				$urlParams['count'] = '1';
 			}
 
 			$request = $this->request(array(


### PR DESCRIPTION
fix bug... said "==" it meant to assign using "="
