### PR TITLE
Allow queries with no where clause

### DIFF
--- a/parseQuery.php
+++ b/parseQuery.php
@@ -24,38 +24,35 @@ class parseQuery extends parseRestClient{
 	}
 
 	public function find(){
-		if(empty($this->_query)){
-			$this->throwError('No query set yet.');
-		}
-		else{
-			$urlParams = array(
-				'where' => json_encode( $this->_query )
-			);
-			if(!empty($this->_include)){
-				$urlParams['include'] = implode(',',$this->_include);
-			}
-			if(!empty($this->_order)){
-				$urlParams['order'] = implode(',',$this->_order);
-			}
-			if(!empty($this->_limit)){
-				$urlParams['limit'] = $this->_limit;
-			}
-			if(!empty($this->_skip)){
-				$urlParams['skip'] = $this->_skip;
-			}
-			if($this->_count == 1){
-				$urlParams['count'] = '1';
-			}
 
-			$request = $this->request(array(
-				'method' => 'GET',
-				'requestUrl' => $this->_requestUrl,
-				'urlParams' => $urlParams,
-			));
-			
-			return $request;
+        $urlParams = array();
 
-		}
+        if(!empty($this->_query)){
+            $urlParams['where'] = json_encode($this->_query);
+        }
+        if(!empty($this->_include)){
+            $urlParams['include'] = implode(',',$this->_include);
+        }
+        if(!empty($this->_order)){
+            $urlParams['order'] = implode(',',$this->_order);
+        }
+        if(!empty($this->_limit)){
+            $urlParams['limit'] = $this->_limit;
+        }
+        if(!empty($this->_skip)){
+            $urlParams['skip'] = $this->_skip;
+        }
+        if($this->_count == 1){
+            $urlParams['count'] = '1';
+        }
+
+        $request = $this->request(array(
+            'method' => 'GET',
+            'requestUrl' => $this->_requestUrl,
+            'urlParams' => $urlParams,
+        ));
+
+        return $request;
 	}
 
 	public function getCount(){


### PR DESCRIPTION
The parse REST API does not require a WHERE clause, this change removes the check in find() that throws an error if query is empty
