### PR TITLE
parseRole.php class and changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 parseConfig.php
+/nbproject/private/

--- a/EnhanceTestFramework.php
+++ b/EnhanceTestFramework.php
@@ -325,6 +325,34 @@ class TextEn
     public $LineFile = 'Line {0} in file {1}';
 }
 
+class TextFr
+{
+    public $FormatForTestRunTook = 'Le test a prit {0} seconds';
+    public $FormatForExpectedButWas = '{0} attendu mais finalement fut {1}';
+    public $FormatForExpectedNotButWas = 'Pas {0} attendu mais finalement fut {1}';
+    public $FormatForExpectedContainsButWas = 'Présence de {0} attendu mais finalement fut {1}';
+    public $FormatForExpectedNotContainsButWas = 'Absence de  {0} attendu mais finalement fut {1}';
+    public $EnhanceTestFramework = 'Enhance Test Framework';
+    public $EnhanceTestFrameworkFull = 'Enhance PHP Framework de Test Unitaire';
+    public $TestResults = 'Résultats des tests ';
+    public $Test = 'Test';
+    public $TestPassed = 'Test Réussi';
+    public $TestFailed = 'Test Échoué';
+    public $Passed = 'Réussi';
+    public $Failed = 'Échoué';
+    public $ExpectationFailed = 'Les attentes ne furent pas atteintes';
+    public $Expected = 'Attendu';
+    public $Called = 'Appelé ';
+    public $InconclusiveOrNotImplemented = 'non conclusif ou pas implémenté';
+    public $Times = 'fois';
+    public $MethodCoverage = 'Couverture des fonctions';
+    public $Copyright = 'Copyright';
+    public $ExpectedExceptionNotThrown = 'L\'exception attendu ne fut pas levée';
+    public $CannotCallVerifyOnStub = 'impossible d\'appeler VerifyExpectations sur la souche';
+    public $ReturnsOrThrowsNotBoth = 'Vous ne pouvez définire qu\une seul valeur de retour(1 returns() ou 1 throws())';
+    public $ScenarioWithExpectMismatch = 'Les scenarios doivent être initialisé avec le même nombre d\'appel à "with" et "expect"';
+    public $LineFile = 'Ligne {0} dans le fichier {1}';
+}
 class TextDe
 {
     public $FormatForTestRunTook = 'Fertig nach {0} Sekunden';
@@ -411,8 +439,36 @@ class TextSp
     public $CannotCallVerifyOnStub = 'No se puede llamar  VerifyExpectations en un stub';
     public $ReturnsOrThrowsNotBoth = 'Debe proporcionar un solo valor de retorno (1 returns() ó 1 throws())';
     public $ScenarioWithExpectMismatch = 'Escenario debe ser inicializado con el mismo número de llamadas "with" y "expect" ';
-	public $LineFile = 'Linha {0} no arquivo {1}';    
-	public $TypeOfVar=" Tipo: ";
+    public $LineFile = 'Linha {0} no arquivo {1}';    
+    public $TypeOfVar=" Tipo: ";
+}
+
+class TextRo{
+    public $FormatForTestRunTook = 'Testul a durat {0} secunde';
+    public $FormatForExpectedButWas = 'Se aștepta {0} dar a returnat {1}';
+    public $FormatForExpectedNotButWas = 'Nu se aștepta {0} dar a returnat {1}';
+    public $FormatForExpectedContainsButWas = 'Se aștepta sa conțină {0} dar conține {1}';
+    public $FormatForExpectedNotContainsButWas = 'Nu se aștepta sa conțină {0} dar conține  {1}';
+    public $EnhanceTestFramework = 'Enhance Test Framework';
+    public $EnhanceTestFrameworkFull = 'Enhance PHP Unit Testing Framework';
+    public $TestResults = 'Rezultate Teste';
+    public $Test = 'Test';
+    public $TestPassed = 'Testul a fost finalizat cu succes.';
+    public $TestFailed = 'Testul a eșuat.';
+    public $Passed = 'Succes';
+    public $Failed = 'Eșuat.';
+    public $ExpectationFailed = 'Așteptare eșuată';
+    public $Expected = 'Așteptare';
+    public $Called = 'Apelat';
+    public $InconclusiveOrNotImplemented = 'Neconcludent sau neimplementat';
+    public $Times = 'Ori';
+    public $MethodCoverage = 'Învăluire metoda';
+    public $Copyright = 'Drepturi de autor';
+    public $ExpectedExceptionNotThrown = 'Se aștepta o excepție dar nu a fost afișata';
+    public $CannotCallVerifyOnStub = 'Nu a putut fi apelata metoda VerifyExpectations pe un stub';
+    public $ReturnsOrThrowsNotBoth = 'Trebuie sa alegi numai o valoare pentru a fi returnata (1 returns() sau 1 throws())';
+    public $ScenarioWithExpectMismatch = 'Scenariul trebuie inițializat cu același număr de apelări la metoda "with" sau "expect" ';
+    public $LineFile = 'Linia {0} in fișierul {1}';
 }
 
 class EnhanceTestFramework
@@ -1730,10 +1786,12 @@ class TemplateType
 
 class Language
 {
+    const French = "Fr";
     const English = 'En';
     const Deutsch = 'De';
     const BrazilianPortuguese = 'PtBr';
-	const Spanish = 'Sp';
+    const Spanish = 'Sp';
+    const Romana = 'Ro';
 }
 
 class Localisation

--- a/parse.php
+++ b/parse.php
@@ -10,11 +10,7 @@ include 'parseRole.php';
 include 'parseCloud.php';
 
 class parseRestClient{
-    public static $APPID;
-    public static $MASTERKEY;
-    public static $RESTKEY;
-    public static $PARSEURL;
-    
+     
 	private $_appid = '';
 	private $_masterkey = '';
 	private $_restkey = '';
@@ -25,10 +21,11 @@ class parseRestClient{
 	public $returnData = '';
 
 	public function __construct(){
-		$this->_appid = parseRestClient::$APPID;
-                $this->_masterkey = parseRestClient::$MASTERKEY;
-                $this->_restkey = parseRestClient::$RESTKEY;
-                $this->_parseurl = parseRestClient::$PARSEURL;
+		$parseConfig = new parseConfig;
+		$this->_appid = $parseConfig::APPID;
+        	$this->_masterkey = $parseConfig::MASTERKEY;
+        	$this->_restkey = $parseConfig::RESTKEY;
+                $this->_parseurl = $parseConfig::PARSEURL;
 
 		if(empty($this->_appid) || empty($this->_restkey) || empty($this->_masterkey)){
 			$this->throwError('You must set your Application ID, Master Key and REST API Key');

--- a/parse.php
+++ b/parse.php
@@ -7,6 +7,7 @@ include 'parseFile.php';
 include 'parsePush.php';
 include 'parseGeoPoint.php';
 include 'parseACL.php';
+include 'parseRole.php';
 
 class parseRestClient{
 

--- a/parse.php
+++ b/parse.php
@@ -134,6 +134,12 @@ class parseRestClient{
 						"objectId" => $params[1]
 					);			
 					break;
+                                case 'relatedTo':
+                                        $return = array(
+                                            "object" => $params[0], // pointer
+                                            "key" => $params[1] // key
+                                        );
+                                        break;
 				case 'geopoint':
 					$return = array(
 						"__type" => "GeoPoint",

--- a/parse.php
+++ b/parse.php
@@ -1,5 +1,4 @@
 <?php
-include 'parseConfig.php';
 include 'parseObject.php';
 include 'parseQuery.php';
 include 'parseUser.php';
@@ -10,7 +9,11 @@ include 'parseACL.php';
 include 'parseRole.php';
 
 class parseRestClient{
-
+    public static $APPID;
+    public static $MASTERKEY;
+    public static $RESTKEY;
+    public static $PARSEURL;
+    
 	private $_appid = '';
 	private $_masterkey = '';
 	private $_restkey = '';
@@ -21,11 +24,10 @@ class parseRestClient{
 	public $returnData = '';
 
 	public function __construct(){
-		$parseConfig = new parseConfig;
-		$this->_appid = $parseConfig::APPID;
-    	$this->_masterkey = $parseConfig::MASTERKEY;
-    	$this->_restkey = $parseConfig::RESTKEY;
-    	$this->_parseurl = $parseConfig::PARSEURL;
+		$this->_appid = parseRestClient::$APPID;
+                $this->_masterkey = parseRestClient::$MASTERKEY;
+                $this->_restkey = parseRestClient::$RESTKEY;
+                $this->_parseurl = parseRestClient::$PARSEURL;
 
 		if(empty($this->_appid) || empty($this->_restkey) || empty($this->_masterkey)){
 			$this->throwError('You must set your Application ID, Master Key and REST API Key');

--- a/parseACL.php
+++ b/parseACL.php
@@ -10,7 +10,7 @@ $acl->setPublicReadAccess(false);
 $acl->setReadAccessForId('user_id',true);
 $acl->setWriteAccessForRole('role_name',true);
 
-$object->ACL($acl);
+$object->ACL($acl->acl);
 $object->save();
 */
 class parseACL{

--- a/parseACL.php
+++ b/parseACL.php
@@ -20,14 +20,13 @@ class parseACL{
 	}
 	private function setAccessForKey($access,$key,$bool){
 		if(!($access == 'read' || $access == 'write')) return;
-		if(is_object($this->acl)) $this->acl = array();
-		if($bool) $this->acl[$key][$access] = true;
+		if($bool) $this->acl->$key->$access = true;
 		else {
-			if(isset($this->acl[$key])){ 
-				unset($this->acl[$key][$access]);
-				if(sizeof($this->acl[$key]) == 0) unset($this->acl[$key]);
+			if(isset($this->acl->$key)){ 
+				unset($this->acl->$key->$access);
+				if(sizeof((array)$this->acl->$key) == 0) unset($this->acl->$key);
 			}
-			if(sizeof($this->acl) == 0) $this->acl = new stdClass();
+			if(sizeof((array)$this->acl) == 0) $this->acl = new stdClass();
 		}
 	}
 	public function setPublicReadAccess($bool){

--- a/parseObject.php
+++ b/parseObject.php
@@ -2,7 +2,7 @@
 
 class parseObject extends parseRestClient{
 	public $_includes = array();
-	private $_className = '';
+	protected $_className = '';
 
 	public function __construct($class=''){
 		if($class != ''){
@@ -21,6 +21,23 @@ class parseObject extends parseRestClient{
 		}
 	}
 
+        public function ACL($acl = null) {
+            if($acl)
+                $this->data['ACL'] = $acl;
+            
+            return $this->data['ACL'];
+        }
+
+        public function setProperty($name, $value) {
+		if($name != '_className'){
+			$this->data[$name] = $value;
+		}
+        }
+
+        public function getProperty($name) {
+            return $this->data[$name];
+        }
+        
 	public function save(){
 		if(count($this->data) > 0 && $this->_className != ''){
 			$request = $this->request(array(
@@ -78,7 +95,7 @@ class parseObject extends parseRestClient{
 			return $request;
 		}		
 	}
-
+        
 	public function addInclude($name){
 		$this->_includes[] = $name;
 	}

--- a/parseObject.php
+++ b/parseObject.php
@@ -21,6 +21,10 @@ class parseObject extends parseRestClient{
 		}
 	}
 
+        public function setClassName($className) {
+            $this->_className = $className;
+        }
+        
         public function ACL($acl = null) {
             if($acl)
                 $this->data['ACL'] = $acl;

--- a/parseQuery.php
+++ b/parseQuery.php
@@ -45,8 +45,6 @@ class parseQuery extends parseRestClient{
         if($this->_count == 1){
             $urlParams['count'] = '1';
         }
-        print_r($this->_requestUrl);
-        print_r($urlParams);
         $request = $this->request(array(
             'method' => 'GET',
             'requestUrl' => $this->_requestUrl,

--- a/parseQuery.php
+++ b/parseQuery.php
@@ -141,6 +141,30 @@ class parseQuery extends parseRestClient{
 	
 	}
 
+        public function whereGreaterThanDate($key,$date){
+		if(isset($key) && isset($date)){
+			$this->_query[$key] = array(
+				'$gt' => $this->dataType('date', $date)
+			);
+		}	
+		else{
+			$this->throwError('the $key and $value parameters must be set when setting a "where" query method');		
+		}
+	
+	}
+
+        public function whereLessThanDate($key,$date){
+		if(isset($key) && isset($date)){
+			$this->_query[$key] = array(
+				'$gt' => $this->dataType('date', $date)
+			);
+		}	
+		else{
+			$this->throwError('the $key and $value parameters must be set when setting a "where" query method');		
+		}
+	
+	}
+
 	public function whereLessThan($key,$value){
 		if(isset($key) && isset($value)){
 			$this->_query[$key] = array(

--- a/parseQuery.php
+++ b/parseQuery.php
@@ -9,7 +9,7 @@ class parseQuery extends parseRestClient{
 	private $_include = array();
 
 	public function __construct($class=''){
-		if($class == 'users'){
+		if($class == 'users' || $class == 'roles'){
 			$this->_requestUrl = $class;
 		}
 		elseif($class != ''){

--- a/parseQuery.php
+++ b/parseQuery.php
@@ -9,7 +9,7 @@ class parseQuery extends parseRestClient{
 	private $_include = array();
 
 	public function __construct($class=''){
-		if($class == 'users' || $class == 'roles' || $class = 'installation'){
+		if($class == 'users' || $class == 'roles' || $class == 'installation'){
 			$this->_requestUrl = $class;
 		}
 		elseif($class != ''){

--- a/parseQuery.php
+++ b/parseQuery.php
@@ -156,7 +156,7 @@ class parseQuery extends parseRestClient{
         public function whereLessThanDate($key,$date){
 		if(isset($key) && isset($date)){
 			$this->_query[$key] = array(
-				'$gt' => $this->dataType('date', $date)
+				'$lt' => $this->dataType('date', $date)
 			);
 		}	
 		else{

--- a/parseQuery.php
+++ b/parseQuery.php
@@ -45,7 +45,8 @@ class parseQuery extends parseRestClient{
         if($this->_count == 1){
             $urlParams['count'] = '1';
         }
-
+        print_r($this->_requestUrl);
+        print_r($urlParams);
         $request = $this->request(array(
             'method' => 'GET',
             'requestUrl' => $this->_requestUrl,
@@ -250,7 +251,28 @@ class parseQuery extends parseRestClient{
 		}
 		
 	}
-
+        
+        /**
+         * Example - to find users with a particular role id
+         * $query->whereRelatedTo('users', '_Role', $roleId);
+         * 
+         * @param type $key
+         * @param type $className
+         * @param type $objectId
+         */
+        public function whereRelatedTo($key,$className,$objectId) {
+            if(isset($key) && isset($className) && isset($objectId)){
+                if($className === 'Role')
+                    $className = '_Role';
+                if($className === 'User')
+                    $className = '_User';
+                $pointer = $this->dataType('pointer', array($className, $objectId));
+                $this->_query['$relatedTo'] = $this->dataType('relatedTo', array($pointer, $key));
+            } else {
+		$this->throwError('the $key and $classname and $objectId parameters must be set when setting a "whereRelatedTo" query method');		
+            }
+        }
+        
 	public function whereInQuery($key,$className,$inQuery){
 		if(isset($key) && isset($className)){
 			$this->_query[$key] = array(

--- a/parseRole.php
+++ b/parseRole.php
@@ -1,0 +1,221 @@
+<?php
+
+
+/**
+ * Handles some of the functionality for Roles described in
+ * https://parse.com/docs/rest#roles
+ *
+ * @author jobiwankanboi
+ */
+class parseRole extends parseObject {
+   
+   public function __construct($name) {
+       if($name != '') {
+           parent::__construct('roles');
+           $this->data['name'] = $name;
+       } else {
+           $this->throwError('include the roleName when creating a parseRole');
+       }
+    }
+
+    /**
+     * Cannot change name of a role.
+     * 
+     * @param type $name
+     * @param type $value
+     */
+    public function __set($name,$value){
+        if($name != '_className' && $name != 'name'){
+                $this->data[$name] = $value;
+        }
+    }
+
+    /*
+    		$parseObject->users = array(
+		    '__op' => 'AddRelation',
+		    'objects' => array( 
+		        $parseObject->dataType('pointer', array('post','8TOXdXf3tz')) 
+		        $parseObject->dataType('pointer', array('post','Ed1nuqPvc')),
+		    )
+		);
+ */
+    
+    /**
+     * https://parse.com/docs/rest#roles-updating
+     * @param type $userIds
+     */
+    public function addUsersToRole($userIds = array()) {
+        $objects = array();
+        foreach ($userIds as $userId) {
+            $objects[] = $this->dataType('pointer', array('_User', $userId));
+        }
+        $this->setProperty('users', array(
+            '__op' => 'AddRelation',
+            'objects' => $objects
+        ));
+    }
+
+    /**
+     * https://parse.com/docs/rest#roles-updating
+     * @param type $userIds
+     */
+    public function removeUsersFromRole($userIds = array()) {
+        $objects = array();
+        foreach ($userIds as $userId) {
+            $objects[] = $this->dataType('pointer', array('_User', $userId));
+        }
+        $this->setProperty('users', array(
+            '__op' => 'RemoveRelation',
+            'objects' => $objects
+        ));
+    }
+
+    /**
+     * https://parse.com/docs/rest#roles-creating
+     * 
+     * @return type
+     */
+    public function save(){
+        if(!$this->data['ACL'])
+           $this->throwError('Must have ACL with role');
+        if(count($this->data) > 0 && $this->_className != ''){
+            $request = $this->request(array(
+                    'method' => 'POST',
+                    'requestUrl' => $this->_className,
+                    'data' => $this->data,
+            ));
+            return $request;
+        }
+    }
+    
+    /**
+     * https://parse.com/docs/rest#roles-retrieving
+     * @param type $id
+     * @return type
+     */
+    public function get($id){
+        if($this->_className != '' || !empty($id)){
+            $request = $this->request(array(
+                    'method' => 'GET',
+                    'requestUrl' => $this->_className.'/'.$id
+            ));
+
+            if(!empty($this->_includes)){
+                    $request['include'] = implode(',', $this->_includes);
+            }
+
+            return $request;
+        }
+    }
+
+    /**
+     * https://parse.com/docs/rest#roles-updating
+     * @param type $id
+     * @return type
+     */
+    public function update($id){
+        if($this->_className != '' || !empty($id)){
+            $request = $this->request(array(
+                    'method' => 'PUT',
+                    'requestUrl' => $this->_className.'/'.$id,
+                    'data' => $this->data,
+            ));
+
+            return $request;
+        }
+    }
+
+    /**
+     * https://parse.com/docs/rest#roles-deleting
+     * @param type $id
+     * @return type
+     */
+    public function delete($id){
+        if($this->_className != '' || !empty($id)){
+            $request = $this->request(array(
+                    'method' => 'DELETE',
+                    'requestUrl' => $this->_className.'/'.$id
+            ));
+
+            return $request;
+        }		
+    }
+
+    /**
+     * 
+     * @param type $field
+     * @param type $amount
+     */
+    public function increment($field,$amount){
+       $this->throwError("function increment makes no sense for role.");
+    }
+    
+    /**
+     * 
+     * @param type $id
+     */
+    public function decrement($id){
+       $this->throwError("function decrement makes no sense for role.");
+    }
+    
+    
+    /**
+     * curl -X POST \
+  -H "X-Parse-Application-Id: Z0GKPdAmkIZsKg9nGgSGU52DQBUP2xavHmACYsAI" \
+  -H "X-Parse-REST-API-Key: lOQHg18qhxveTkNA6YGIWDtwBpwQ9ULyK2ZwPqTh" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "Moderators",
+        "ACL": {
+          "*": {
+            "read": true
+          }
+        }
+      }' \
+  https://api.parse.com/1/roles
+     */
+    
+    /**
+     * curl -X POST \
+  -H "X-Parse-Application-Id: Z0GKPdAmkIZsKg9nGgSGU52DQBUP2xavHmACYsAI" \
+  -H "X-Parse-REST-API-Key: lOQHg18qhxveTkNA6YGIWDtwBpwQ9ULyK2ZwPqTh" \
+  -H "Content-Type: application/json" \
+  -d '{"score":1337,"playerName":"Sean Plott","cheatMode":false}' \
+  https://api.parse.com/1/classes/GameScore
+     * 
+     */
+    
+    /**
+     * curl -X PUT \
+  -H "X-Parse-Application-Id: Z0GKPdAmkIZsKg9nGgSGU52DQBUP2xavHmACYsAI" \
+  -H "X-Parse-REST-API-Key: lOQHg18qhxveTkNA6YGIWDtwBpwQ9ULyK2ZwPqTh" \
+  -H "Content-Type: application/json" \
+  -d '{"opponents":{"__op":"AddRelation","objects":[{"__type":"Pointer","className":"Player","objectId":"Vx4nudeWn"}]}}' \
+  https://api.parse.com/1/classes/GameScore/Ed1nuqPvcm
+     * 
+     * curl -X PUT \
+  -H "X-Parse-Application-Id: Z0GKPdAmkIZsKg9nGgSGU52DQBUP2xavHmACYsAI" \
+  -H "X-Parse-Master-Key: F3ywLEYgKT9JzxQKCX6L2UG7Ni6Aq7oIOlZWxVf0" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "users": {
+          "__op": "AddRelation",
+          "objects": [
+            {
+              "__type": "Pointer",
+              "className": "_User",
+              "objectId": "8TOXdXf3tz"
+            },
+            {
+              "__type": "Pointer",
+              "className": "_User",
+              "objectId": "g7y9tkhB7O"
+            }
+          ]
+        }
+      }' \
+  https://api.parse.com/1/roles/mrmBZvsErB
+     */
+}
+
+?>

--- a/parseUser.php
+++ b/parseUser.php
@@ -195,6 +195,5 @@ class parseUser extends parseRestClient{
 		}
 
 	}
-
-
+}
 ?>

--- a/parseUser.php
+++ b/parseUser.php
@@ -155,6 +155,13 @@ class parseUser extends parseRestClient{
 		$this->_includes[] = $name;
 	}
 
+        public function ACL($acl = null) {
+            if($acl)
+                $this->data['ACL'] = $acl;
+            
+            return $this->data['ACL'];
+        }
+
 }
 
 ?>

--- a/parseUser.php
+++ b/parseUser.php
@@ -1,7 +1,7 @@
 <?php
 
 class parseUser extends parseRestClient{
-
+	public $_includes = array();
 	public $authData;
 
 	public function __set($name,$value){
@@ -56,6 +56,9 @@ class parseUser extends parseRestClient{
 				'method' => 'GET',
 	    		'requestUrl' => 'users/'.$objectId,
 			));
+			if(!empty($this->_includes)){
+				$request['include'] = implode(',', $this->_includes);
+			}
 			
 	    	return $request;			
 			
@@ -146,7 +149,11 @@ class parseUser extends parseRestClient{
 		}		
 
 	}
-	
+        
+	public function addInclude($name){
+		$this->_includes[] = $name;
+	}
+
 }
 
 ?>

--- a/parseUser.php
+++ b/parseUser.php
@@ -50,21 +50,21 @@ class parseUser extends parseRestClient{
 	
 	}
 
-public function socialLogin(){
-	if(!empty($this->authData)){
-		$request = $this->request( array(
-			'method' => 'POST',
-			'requestUrl' => 'users',
-			'data' => array(
-				'authData' => $this->authData
-			)
-		));
-		return $request;
+	public function socialLogin(){
+		if(!empty($this->authData)){
+			$request = $this->request( array(
+				'method' => 'POST',
+				'requestUrl' => 'users',
+				'data' => array(
+					'authData' => $this->authData
+				)
+			));
+			return $request;
+		}
+		else{
+			$this->throwError('authArray must be set use addAuthData method');
+		}
 	}
-	else{
-		$this->throwError('authArray must be set use addAuthData method');
-	}
-}
 
 	public function get($objectId){
                 if(!empty($this->_includes)){
@@ -180,7 +180,7 @@ public function socialLogin(){
 
 	public function requestPasswordReset($email){
 		if(!empty($email)){
-			$this->email - $email;
+			$this->email = $email;
 			$request = $this->request(array(
 			'method' => 'POST',
 			'requestUrl' => 'requestPasswordReset',
@@ -194,7 +194,7 @@ public function socialLogin(){
 			$this->throwError('email is required for the requestPasswordReset method');
 		}
 
-}
+	}
 
 
 ?>

--- a/parseUser.php
+++ b/parseUser.php
@@ -51,14 +51,15 @@ class parseUser extends parseRestClient{
 	}
 
 	public function get($objectId){
+                if(!empty($this->_includes)){
+                        $request['include'] = implode(',', $this->_includes);
+                }
+                
 		if($objectId != ''){
 			$request = $this->request(array(
 				'method' => 'GET',
 	    		'requestUrl' => 'users/'.$objectId,
 			));
-			if(!empty($this->_includes)){
-				$request['include'] = implode(',', $this->_includes);
-			}
 			
 	    	return $request;			
 			

--- a/tests/parseRoleTest.php
+++ b/tests/parseRoleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ *
+ * @author jobiwankanobi
+ */
+include_once('../EnhanceTestFramework.php');
+include_once('../parse.php');
+
+class parseRoleTest extends \Enhance\TestFixture {
+    
+    public $parseRole;
+    public $parseUser;
+    public $testUser;
+    
+    public function setUp(){
+        $this->parseRole = \Enhance\Core::getCodeCoverageWrapper('parseRole', array('TestRole'));
+        $this->parseUser = new parseUser();
+        $this->testUser = array(
+                'username' => 'testUser'.rand(),
+                'password' => 'testPass',
+                'email' => 'testUser@parse.com',
+                'customField' => 'customValue'
+        );
+
+    }
+
+    public function testCreateRole(){
+        $parseRole = $this->parseRole;
+        $parseACL = new parseACL();
+        $parseACL->setPublicReadAccess(true);
+        $parseACL->setPublicWriteAccess(false);
+        $parseACL->setWriteAccessForRole('Administrator', true);
+        
+        $parseRole->ACL( $parseACL->acl );
+        try {
+            $return = $parseRole->save();
+        } catch (ParseLibraryException $e) {
+            throw $e;
+        }
+        \Enhance\Assert::isTrue( is_object($return) );
+        \Enhance\Assert::isNotNull($return->objectId);
+        $parseRole->setProperty('objectId', $return->objectId);
+        
+        $parseRole2 = $parseRole;
+        $return = $parseRole2->get($parseRole2->getProperty('objectId'));
+        \Enhance\Assert::isObject($return);
+        
+        $return = $parseRole2->delete($parseRole2->getProperty('objectId'));
+    }
+    
+    public function testAddAndRemoveRoleForUser() {
+        $parseUser = $this->parseUser;
+        $retUser = $parseUser->signup($this->testUser['username'], $this->testUser['password']);
+
+        // Recreate role
+        $parseRole = $this->parseRole;
+        $parseACL = new parseACL();
+        $parseACL->setPublicReadAccess(true);
+        $parseACL->setPublicWriteAccess(false);
+        $parseACL->setWriteAccessForRole('Administrator', true);
+        
+        $parseRole->ACL( $parseACL->acl );
+        try {
+            $return = $parseRole->save();
+            $objectId = $return->objectId;
+        } catch (ParseLibraryException $e) {
+            throw $e;
+        }
+        
+        $parseRole2 = new parseRole('TestRole');
+        $parseRole2->addUsersToRole(array($retUser->objectId));
+        $return = $parseRole2->update($objectId);
+        \Enhance\Assert::isObject($return);
+        \Enhance\Assert::isNotNull($return->updatedAt);
+
+        $parseRole2->removeUsersFromRole(array($retUser->objectId));
+        $return2 = $parseRole2->update($objectId);
+        \Enhance\Assert::isObject($return2);
+        \Enhance\Assert::isNotNull($return2->updatedAt);
+        
+    }
+}
+
+// Run the tests
+\Enhance\Core::runTests();
+
+?>

--- a/tests/parseRoleTest.php
+++ b/tests/parseRoleTest.php
@@ -14,6 +14,10 @@ class parseRoleTest extends \Enhance\TestFixture {
     public $testUser;
     
     public function setUp(){
+        parseRestClient::$APPID = '22cASrmG1cWQ8LuV1kNRWjQjjpjf2rA9neNZMlLj';  // test app
+        parseRestClient::$MASTERKEY = 'WDXgAfDXybXJpswDacf5M4QzKT22Uxov85D12A8M';
+        parseRestClient::$RESTKEY = '6tKoG4XataK6FUKJEOdxjy4xAo9J4taNit0BnMfH';
+        parseRestClient::$PARSEURL = 'https://api.parse.com/1/';
         $this->parseRole = \Enhance\Core::getCodeCoverageWrapper('parseRole', array('TestRole'));
         $this->parseUser = new parseUser();
         $this->testUser = array(
@@ -74,11 +78,19 @@ class parseRoleTest extends \Enhance\TestFixture {
         \Enhance\Assert::isObject($return);
         \Enhance\Assert::isNotNull($return->updatedAt);
 
+        // Query parse role
+        $query = new parseQuery('users');
+        $query->whereRelatedTo('users', 'Role', $objectId);
+        $ret = $query->find();
+        \Enhance\Assert::isArray($ret);
+        \Enhance\Assert::isTrue(count($ret) == 1);
+
         $parseRole2->removeUsersFromRole(array($retUser->objectId));
         $return2 = $parseRole2->update($objectId);
         \Enhance\Assert::isObject($return2);
         \Enhance\Assert::isNotNull($return2->updatedAt);
-        
+
+        $parseRole2->delete($objectId);
     }
 }
 


### PR DESCRIPTION
Added a parseRole.php class and tests.  It can create, update, and delete roles, as well as adding users to roles, and deleting users from roles.  It doesn't do everything roles can do, like adding or deleting child roles.  Use parseACL to assign ACL privileges to roles.
