### PR TITLE
adding the config as array not as a const of a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,13 @@ Below is what you want parseConfig.php to look like, just fill in your IDs and K
 
 ```
 <?php
-
-class parseConfig{
-	
-	const APPID = '';
-	const MASTERKEY = '';
-	const RESTKEY = '';
-	const PARSEURL = 'https://api.parse.com/1/';
-}
-
+    $config = array(
+        "APPID"=>'',
+        "MASTERKEY"=>'',
+        "RESTKEY"=>'',
+        "PARSEURL"=>'https://api.parse.com/1/'
+    );
 ?>
-
 ```
 
 
@@ -49,7 +45,7 @@ EXAMPLE
 <?php 
     //This example is a sample video upload stored in parse
     
-    $parse = new parseObject('Videos');
+    $parse = new parseObject($config,'Videos');
     $parse->title = $data['upload_data']['title'];
     $parse->description = $data['upload_data']['description'];
     $parse->tags = $data['upload_data']['tags'];

--- a/parse.php
+++ b/parse.php
@@ -20,12 +20,11 @@ class parseRestClient{
 	public $requestUrl = '';
 	public $returnData = '';
 
-	public function __construct(){
-		$parseConfig = new parseConfig;
-		$this->_appid = $parseConfig::APPID;
-    	$this->_masterkey = $parseConfig::MASTERKEY;
-    	$this->_restkey = $parseConfig::RESTKEY;
-    	$this->_parseurl = $parseConfig::PARSEURL;
+	public function __construct($config){
+		$this->_appid = $config['APPID'];
+    	$this->_masterkey = $config['MASTERKEY'];
+    	$this->_restkey = $config['RESTKEY'];
+    	$this->_parseurl = $config['PARSEURL'];
 
 		if(empty($this->_appid) || empty($this->_restkey) || empty($this->_masterkey)){
 			$this->throwError('You must set your Application ID, Master Key and REST API Key');

--- a/parseCloud.php
+++ b/parseCloud.php
@@ -13,7 +13,7 @@ class parseCloud extends parseRestClient{
 	public $_options;
 	private $_functionName = '';
 
-	public function __construct($function=''){
+	public function __construct($config,$function=''){
 		$this->_options = array();
 		if($function != ''){
 			$this->_functionName = $function; 
@@ -22,7 +22,7 @@ class parseCloud extends parseRestClient{
 			$this->throwError('include the functionName when creating a parseCloud');
 		}
 
-		parent::__construct();
+		parent::__construct($config);
 	}
 
 	public function __set($name,$value){

--- a/parseFile.php
+++ b/parseFile.php
@@ -5,13 +5,13 @@ class parseFile extends parseRestClient{
 	private $_fileName;
 	private $_contentType;
 
-	public function __construct($contentType='',$data=''){
+	public function __construct($confog,$contentType='',$data=''){
 		if($contentType != '' && $data !=''){
 			$this->_contentType = $contentType;
 			$this->data = $data;
 		}
 		
-		parent::__construct();
+		parent::__construct($confog);
 
 	}
 

--- a/parseObject.php
+++ b/parseObject.php
@@ -4,7 +4,7 @@ class parseObject extends parseRestClient{
 	public $_includes = array();
 	private $_className = '';
 
-	public function __construct($class=''){
+	public function __construct($config,$class=''){
 		if($class != ''){
 			$this->_className = $class;
 		}
@@ -12,7 +12,7 @@ class parseObject extends parseRestClient{
 			$this->throwError('include the className when creating a parseObject');
 		}
 
-		parent::__construct();
+		parent::__construct($config);
 	}
 
 	public function __set($name,$value){

--- a/parsePush.php
+++ b/parsePush.php
@@ -13,12 +13,12 @@ class parsePush extends parseRestClient{
 
 	private $_globalMsg;
 
-	public function __construct($globalMsg=''){
+	public function __construct($config,$globalMsg=''){
 		if($globalMsg != ''){
 			$this->_globalMsg = $globalMsg;
 		}
 		
-		parent::__construct();
+		parent::__construct($config);
 
 	}
 	

--- a/parseQuery.php
+++ b/parseQuery.php
@@ -8,7 +8,7 @@ class parseQuery extends parseRestClient{
 	private $_query = array();
 	private $_include = array();
 
-	public function __construct($class=''){
+	public function __construct($config,$class=''){
 		if($class == 'users'){
 			$this->_requestUrl = $class;
 		}
@@ -19,7 +19,7 @@ class parseQuery extends parseRestClient{
 			$this->throwError('include the className when creating a parseQuery');
 		}
 		
-		parent::__construct();
+		parent::__construct($config);
 
 	}
 


### PR DESCRIPTION
i have change the way of the config, so instead of creating a class for
the config, and this will force you to have only one APP from
parse.com, you can just pass the config array to the constructor so
that you can now use the sam library with many apps based on the keys
not only one app.
