### PR TITLE
parseQuery additions

### DIFF
--- a/parseQuery.php
+++ b/parseQuery.php
@@ -9,7 +9,7 @@ class parseQuery extends parseRestClient{
 	private $_include = array();
 
 	public function __construct($class=''){
-		if($class == 'users'){
+		if($class == 'users' || $class == 'installations'){
 			$this->_requestUrl = $class;
 		}
 		elseif($class != ''){
@@ -24,38 +24,35 @@ class parseQuery extends parseRestClient{
 	}
 
 	public function find(){
-		if(empty($this->_query)){
-			$this->throwError('No query set yet.');
-		}
-		else{
+		if(!empty($this->_query)){
 			$urlParams = array(
 				'where' => json_encode( $this->_query )
 			);
-			if(!empty($this->_include)){
-				$urlParams['include'] = implode(',',$this->_include);
-			}
-			if(!empty($this->_order)){
-				$urlParams['order'] = implode(',',$this->_order);
-			}
-			if(!empty($this->_limit)){
-				$urlParams['limit'] = $this->_limit;
-			}
-			if(!empty($this->_skip)){
-				$urlParams['skip'] = $this->_skip;
-			}
-			if($this->_count == 1){
-				$urlParams['count'] = '1';
-				$urlParams['limit'] = '0';
-			}
-			
-			$request = $this->request(array(
-				'method' => 'GET',
-				'requestUrl' => $this->_requestUrl,
-				'urlParams' => $urlParams,
-			));
-
-			return $request;
 		}
+		if(!empty($this->_include)){
+			$urlParams['include'] = implode(',',$this->_include);
+		}
+		if(!empty($this->_order)){
+			$urlParams['order'] = implode(',',$this->_order);
+		}
+		if(!empty($this->_limit)){
+			$urlParams['limit'] = $this->_limit;
+		}
+		if(!empty($this->_skip)){
+			$urlParams['skip'] = $this->_skip;
+		}
+		if($this->_count == 1){
+			$urlParams['count'] = '1';
+			$urlParams['limit'] = '0';
+		}
+		
+		$request = $this->request(array(
+			'method' => 'GET',
+			'requestUrl' => $this->_requestUrl,
+			'urlParams' => $urlParams,
+		));
+
+		return $request;
 	}
 
 	public function getCount(){


### PR DESCRIPTION
- Removed requirement for parseQuery to have a query set. This allows you to get all objects, the ObjectiveC lib allows this, see below.
  
  > PFQuery *query = [PFQuery queryWithClassName:CLASS];
  > [query findObjects];
- Added ability to get 'installations' with a parseQuery.
