### PR TITLE
Fixed incrementing and decrementing fields on parseObject.

### DIFF
--- a/parse.php
+++ b/parse.php
@@ -160,13 +160,13 @@ class parseRestClient{
 				case 'increment':
 					$return = array(
 						"__op" => "Increment",
-						"amount" => $params[0]
+						"amount" => $params
 					);
 					break;
 				case 'decrement':
 					$return = array(
 						"__op" => "Decrement",
-						"amount" => $params[0]
+						"amount" => $params
 					);
 					break;
 				default:

--- a/parseObject.php
+++ b/parseObject.php
@@ -63,7 +63,7 @@ class parseObject extends parseRestClient{
 		$this->data[$field] = $this->dataType('increment', $amount);
 	}
 
-	public function decrement($id, $amount){
+	public function decrement($field, $amount){
 		$this->data[$field] = $this->dataType('decrement', $amount);
 	}
 

--- a/parseObject.php
+++ b/parseObject.php
@@ -59,11 +59,11 @@ class parseObject extends parseRestClient{
 		}
 	}
 
-	public function increment($field,$amount){
+	public function increment($field, $amount){
 		$this->data[$field] = $this->dataType('increment', $amount);
 	}
 
-	public function decrement($id){
+	public function decrement($id, $amount){
 		$this->data[$field] = $this->dataType('decrement', $amount);
 	}
 


### PR DESCRIPTION
Previously not working due to incorrect data type being expected, and incorrect variable name.
