### PR TITLE
"include" bug fix

### DIFF
--- a/parseObject.php
+++ b/parseObject.php
@@ -34,14 +34,16 @@ class parseObject extends parseRestClient{
 
 	public function get($id){
 		if($this->_className != '' || !empty($id)){
+			$urlParams = array();
+			if(!empty($this->_includes)){
+				$urlParams['include'] = implode(',',$this->_includes);
+			}
+			
 			$request = $this->request(array(
 				'method' => 'GET',
-				'requestUrl' => 'classes/'.$this->_className.'/'.$id
+				'requestUrl' => 'classes/'.$this->_className.'/'.$id,
+				'urlParams' => $urlParams
 			));
-			
-			if(!empty($this->_includes)){
-				$request['include'] = implode(',', $this->_includes);
-			}
 			
 			return $request;
 		}


### PR DESCRIPTION
When retrieving objects that have pointers to children, you can fetch child objects by using the include option.
