### PR TITLE
Fixed bug in find() method

### DIFF
--- a/parseQuery.php
+++ b/parseQuery.php
@@ -24,7 +24,7 @@ class parseQuery extends parseRestClient{
 	}
 
 	public function find(){
-		if(empty($this->_query)){
+		if(empty($this->_query) && !empty($this->_order)) {
 			$request = $this->request(array(
 				'method' => 'GET',
 				'requestUrl' => $this->_requestUrl


### PR DESCRIPTION
If you issue a query without any operands but have orderBy statements, the find() query does not include the "orderBy" fields.  This is useful where you want to list _all_ objects within class and order by title.
